### PR TITLE
Fix: wazo-router-confd has version prefix in API end-points (/1.0)

### DIFF
--- a/kamailio/kamailio-local.cfg.example
+++ b/kamailio/kamailio-local.cfg.example
@@ -1,9 +1,9 @@
 # *** Value defines - IDs used later in config
 
 /* API endpoints */
-# #!define HTTP_API_ROUTING_ENDPOINT "http://wazo-router-confd:8000/kamailio/routing"
-# #!define HTTP_API_CDR_ENDPOINT "http://wazo-router-confd:8000/kamailio/cdr"
-# #!define HTTP_API_DBTEXT_UACREG_ENDPOINT "http://wazo-router-confd:8000/kamailio/dbtext/uacreg"
+# #!define HTTP_API_ROUTING_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/routing"
+# #!define HTTP_API_CDR_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/cdr"
+# #!define HTTP_API_DBTEXT_UACREG_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/dbtext/uacreg"
 
 /* set the auth SECRET, defaults to randomly generated string */
 # #!define ROUTER_AUTH_SECRET "wazo"

--- a/kamailio/kamailio-local.cfg.example
+++ b/kamailio/kamailio-local.cfg.example
@@ -1,9 +1,9 @@
 # *** Value defines - IDs used later in config
 
 /* API endpoints */
-# #!define HTTP_API_ROUTING_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/routing"
-# #!define HTTP_API_CDR_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/cdr"
-# #!define HTTP_API_DBTEXT_UACREG_ENDPOINT "http://wazo-router-confd:8000/1.0/kamailio/dbtext/uacreg"
+# #!define HTTP_API_ROUTING_ENDPOINT "http://wazo-router-confd:9600/1.0/kamailio/routing"
+# #!define HTTP_API_CDR_ENDPOINT "http://wazo-router-confd:9600/1.0/kamailio/cdr"
+# #!define HTTP_API_DBTEXT_UACREG_ENDPOINT "http://wazo-router-confd:9600/1.0/kamailio/dbtext/uacreg"
 
 /* set the auth SECRET, defaults to randomly generated string */
 # #!define ROUTER_AUTH_SECRET "wazo"

--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -68,7 +68,7 @@ import_file "kamailio-local.cfg"
 #!endif
 
 #!ifndef LISTEN_XHTTP
-#!define LISTEN_XHTTP tcp:eth0:8000
+#!define LISTEN_XHTTP tcp:eth0:9600
 #!endif
 
 #!ifndef REG_CONTACT_ADDRESS


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-c4/pull/4